### PR TITLE
[codex] Show most starred GitHub projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The live portfolio includes detailed professional experience, technical skills a
 ## ✨ Features
 
 - 🎨 **Modern Design** - Clean, responsive interface with dark/light theme support
-- 🚀 **Performance Optimized** - Fast loading with vanilla JavaScript and GitHub Search API integration
+- 🚀 **Performance Optimized** - Fast loading with vanilla JavaScript and a reusable most-starred repository feed
 - 🔍 **SEO & Social Ready** - Static meta tags and resource preloading for better visibility
 - ♿ **Accessible** - Built with semantic HTML `<details>`/`<summary>` for better screen reader support
 - 📱 **Mobile First** - Fully responsive across all devices
-- 🔄 **Auto-Updated** - Content dynamically generated from `config.json`
+- 🔄 **Auto-Updated** - Content dynamically generated from `config.json` and the GitHub profile repository feed
 - 🌓 **Dark/Light Mode** - Smooth transitions with persistent preferences
 - 🔗 **Dynamic Social Links** - Configurable social media and professional links
 - 🔝 **Smooth Navigation** - Integrated Scroll-to-Top feature

--- a/config.json
+++ b/config.json
@@ -227,7 +227,12 @@
     ]
   },
   "github_projects": {
-    "title": "Projects on GitHub"
+    "title": "Most Starred GitHub Projects",
+    "source_url": "https://raw.githubusercontent.com/yashrajnayak/yashrajnayak/master/data/top-repos.json",
+    "max_repos": 6,
+    "excluded_repos": [
+      "yashrajnayak"
+    ]
   },
   "footer": {
     "show_social_links": true,

--- a/css/bundle.css
+++ b/css/bundle.css
@@ -1066,18 +1066,68 @@ h1 {
 
 .project-card h3 {
     color: var(--primary-color);
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
     font-family: var(--font-display);
     font-size: 1.125rem;
     font-weight: 700;
 }
 
+.project-card h3 a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.project-card h3 a:hover {
+    text-decoration: underline;
+}
+
+.project-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    margin-bottom: 1rem;
+    color: var(--text-muted);
+}
+
+.project-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.project-stat .material-symbols-outlined {
+    color: var(--primary-color);
+    font-size: 1rem;
+    font-variation-settings: 'FILL' 0, 'wght' 500, 'GRAD' 0, 'opsz' 20;
+}
+
 .project-card p {
     color: var(--text-muted);
-    margin-bottom: 2rem;
+    margin-bottom: 1.25rem;
     flex: 1;
     font-size: 0.875rem;
     line-height: 1.6;
+}
+
+.project-topics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.project-topics span {
+    color: var(--text-muted);
+    background-color: var(--background-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-full);
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.2;
 }
 
 .project-links {
@@ -1087,6 +1137,11 @@ h1 {
     position: absolute;
     bottom: 1.5rem;
     left: 1.5rem;
+}
+
+.project-card .project-links {
+    position: static;
+    margin-top: auto;
 }
 
 .project-links a {

--- a/css/projects.css
+++ b/css/projects.css
@@ -285,18 +285,68 @@
 
 .project-card h3 {
     color: var(--primary-color);
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
     font-family: var(--font-display);
     font-size: 1.125rem;
     font-weight: 700;
 }
 
+.project-card h3 a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.project-card h3 a:hover {
+    text-decoration: underline;
+}
+
+.project-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    margin-bottom: 1rem;
+    color: var(--text-muted);
+}
+
+.project-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.project-stat .material-symbols-outlined {
+    color: var(--primary-color);
+    font-size: 1rem;
+    font-variation-settings: 'FILL' 0, 'wght' 500, 'GRAD' 0, 'opsz' 20;
+}
+
 .project-card p {
     color: var(--text-muted);
-    margin-bottom: 2rem;
+    margin-bottom: 1.25rem;
     flex: 1;
     font-size: 0.875rem;
     line-height: 1.6;
+}
+
+.project-topics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.project-topics span {
+    color: var(--text-muted);
+    background-color: var(--background-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-full);
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1.2;
 }
 
 .project-links {
@@ -306,6 +356,11 @@
     position: absolute;
     bottom: 1.5rem;
     left: 1.5rem;
+}
+
+.project-card .project-links {
+    position: static;
+    margin-top: auto;
 }
 
 .project-links a {

--- a/index.html
+++ b/index.html
@@ -38,9 +38,11 @@
     <link rel="manifest" href="site.webmanifest">
     <link rel="preload" href="css/bundle.css" as="style">
     <link rel="preconnect" href="https://avatars.githubusercontent.com">
+    <link rel="preconnect" href="https://raw.githubusercontent.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="dns-prefetch" href="https://api.github.com">
+    <link rel="dns-prefetch" href="https://raw.githubusercontent.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" rel="stylesheet">
     <link rel="stylesheet" href="css/bundle.css">
@@ -171,10 +173,10 @@
             <h2></h2>
         </section>
 
-        <section class="projects-on-github" aria-label="GitHub projects">
+        <section class="projects-on-github" aria-label="Most starred GitHub projects">
             <h2></h2>
             <div id="projects" class="projects-grid">
-                <div class="loading" role="status">Loading projects...</div>
+                <div class="loading" role="status">Loading repositories...</div>
             </div>
         </section>
     </div>

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -571,6 +571,7 @@ class GitHubProjectsManager {
     constructor() {
         this.projectsContainer = null;
         this.requestTimeoutMs = 5000;
+        this.defaultMaxRepos = 6;
     }
 
     async fetchJson(url) {
@@ -598,10 +599,86 @@ class GitHubProjectsManager {
         this.projectsContainer.replaceChildren(messageElement);
     }
 
-    // Fetch GitHub projects with "featured" topic using Search API
+    getSettings(config) {
+        const settings = config.github_projects || {};
+        const username = config.github_username;
+        const excludedRepos = new Set([
+            username,
+            ...(settings.excluded_repos || [])
+        ].filter(Boolean));
+
+        return {
+            sourceUrl: settings.source_url,
+            maxRepos: Number.isInteger(settings.max_repos) ? settings.max_repos : this.defaultMaxRepos,
+            excludedRepos
+        };
+    }
+
+    normalizeRepo(repo) {
+        return {
+            name: repo.name,
+            description: repo.description || '',
+            url: repo.html_url || repo.url,
+            homepage: repo.homepage || '',
+            language: repo.language || '',
+            stars: repo.stars ?? repo.stargazers_count ?? 0,
+            forks: repo.forks ?? repo.forks_count ?? 0,
+            topics: repo.topics || [],
+            updatedAt: repo.updatedAt || repo.updated_at || '',
+            pushedAt: repo.pushedAt || repo.pushed_at || ''
+        };
+    }
+
+    getDisplayRepos(repos, settings) {
+        return repos
+            .map(repo => this.normalizeRepo(repo))
+            .filter(repo => repo.name && repo.url)
+            .filter(repo => !settings.excludedRepos.has(repo.name))
+            .sort((a, b) => {
+                if (b.stars !== a.stars) {
+                    return b.stars - a.stars;
+                }
+
+                const bDate = Date.parse(b.pushedAt || b.updatedAt) || 0;
+                const aDate = Date.parse(a.pushedAt || a.updatedAt) || 0;
+                return bDate - aDate;
+            })
+            .slice(0, settings.maxRepos);
+    }
+
+    async fetchFromProfileFeed(settings) {
+        if (!settings.sourceUrl) {
+            return [];
+        }
+
+        const repos = await this.fetchJson(settings.sourceUrl);
+        if (!Array.isArray(repos)) {
+            throw new Error('Top repositories feed must return an array');
+        }
+
+        return this.getDisplayRepos(repos, settings);
+    }
+
+    async fetchFromGitHubSearch(username, settings) {
+        const query = encodeURIComponent(`user:${username} fork:false archived:false`);
+        const perPage = Math.min(100, settings.maxRepos + settings.excludedRepos.size + 5);
+        const data = await this.fetchJson(`https://api.github.com/search/repositories?q=${query}&sort=stars&order=desc&per_page=${perPage}`);
+
+        return this.getDisplayRepos(data.items || [], settings);
+    }
+
+    async fetchFromGitHubRepos(username, settings) {
+        const repos = await this.fetchJson(`https://api.github.com/users/${username}/repos?type=owner&sort=updated&per_page=100`);
+        const publicRepos = repos.filter(repo => !repo.fork && !repo.archived);
+
+        return this.getDisplayRepos(publicRepos, settings);
+    }
+
+    // Fetch most-starred GitHub projects from the profile feed, then fall back to GitHub APIs.
     async fetchGitHubProjects(config) {
         this.projectsContainer = document.getElementById('projects');
         const username = config.github_username;
+        const settings = this.getSettings(config);
 
         if (!this.projectsContainer) {
             console.warn('Projects container not found, skipping GitHub projects');
@@ -614,41 +691,106 @@ class GitHubProjectsManager {
         }
         
         try {
-            // Clear loading message
             this.projectsContainer.innerHTML = '';
-            
-            // Use GitHub Search API to find repositories with the "featured" topic
-            // This is more efficient than fetching all repos and filtering in the browser
-            const query = encodeURIComponent(`user:${username} topic:featured`);
-            const data = await this.fetchJson(`https://api.github.com/search/repositories?q=${query}&sort=updated&order=desc`);
-            const featuredRepos = data.items || [];
-            
-            if (featuredRepos.length > 0) {
-                this.renderProjects(featuredRepos, username);
-            } else {
-                this.setMessage('No featured repositories found.');
+
+            const topRepos = await this.fetchFromProfileFeed(settings);
+
+            if (topRepos.length > 0) {
+                this.renderProjects(topRepos, username);
+                return;
             }
+
+            throw new Error('Top repositories feed did not return any projects');
         } catch (error) {
-            console.warn('GitHub Search API failed, falling back to all repos fetch', error);
-            return this.fetchGitHubProjectsFallback(username);
+            console.warn('Top repositories feed failed, falling back to GitHub Search API', error);
+            return this.fetchGitHubProjectsFallback(username, settings);
         }
     }
 
-    // Fallback method to fetch all repos if Search API is unavailable
-    async fetchGitHubProjectsFallback(username) {
+    // Fallback method to fetch most-starred repos if the profile feed is unavailable
+    async fetchGitHubProjectsFallback(username, settings) {
         try {
-            const repos = await this.fetchJson(`https://api.github.com/users/${username}/repos?sort=updated&per_page=100`);
-            const featuredRepos = repos.filter(repo => repo.topics && repo.topics.includes('featured'));
-            
-            if (featuredRepos.length > 0) {
-                this.renderProjects(featuredRepos, username);
+            const topRepos = await this.fetchFromGitHubSearch(username, settings);
+
+            if (topRepos.length > 0) {
+                this.renderProjects(topRepos, username);
+                return;
+            }
+
+            throw new Error('GitHub Search API did not return any projects');
+        } catch (error) {
+            console.warn('GitHub Search API failed, falling back to user repositories', error);
+            return this.fetchGitHubProjectsReposFallback(username, settings);
+        }
+    }
+
+    async fetchGitHubProjectsReposFallback(username, settings) {
+        try {
+            const topRepos = await this.fetchFromGitHubRepos(username, settings);
+
+            if (topRepos.length > 0) {
+                this.renderProjects(topRepos, username);
             } else {
-                this.setMessage('No featured repositories found.');
+                this.setMessage('No public repositories found.');
             }
         } catch (error) {
             this.setMessage('GitHub projects are temporarily unavailable.');
             console.error('Error loading GitHub projects:', error);
         }
+    }
+
+    formatNumber(value) {
+        return new Intl.NumberFormat('en-US').format(value || 0);
+    }
+
+    createProjectMeta(repo) {
+        const meta = document.createElement('div');
+        meta.className = 'project-meta';
+
+        const stats = [
+            { icon: 'star', label: `${this.formatNumber(repo.stars)} stars` },
+            { icon: 'call_split', label: `${this.formatNumber(repo.forks)} forks` }
+        ];
+
+        if (repo.language) {
+            stats.push({ icon: 'code', label: repo.language });
+        }
+
+        stats.forEach(stat => {
+            const item = document.createElement('span');
+            item.className = 'project-stat';
+
+            const icon = document.createElement('span');
+            icon.className = 'material-symbols-outlined';
+            icon.setAttribute('aria-hidden', 'true');
+            icon.textContent = stat.icon;
+
+            const label = document.createElement('span');
+            label.textContent = stat.label;
+
+            item.append(icon, label);
+            meta.appendChild(item);
+        });
+
+        return meta;
+    }
+
+    createTopics(repo) {
+        const topics = repo.topics.slice(0, 3);
+        if (topics.length === 0) {
+            return null;
+        }
+
+        const topicList = document.createElement('div');
+        topicList.className = 'project-topics';
+
+        topics.forEach(topic => {
+            const item = document.createElement('span');
+            item.textContent = topic;
+            topicList.appendChild(item);
+        });
+
+        return topicList;
     }
 
     // Render GitHub projects
@@ -671,16 +813,26 @@ class GitHubProjectsManager {
         card.style.animationDelay = `${index * 0.1}s`;
 
         const title = document.createElement('h3');
-        title.textContent = repo.name;
+        const titleLink = document.createElement('a');
+        titleLink.href = repo.url;
+        titleLink.target = '_blank';
+        titleLink.rel = 'noopener noreferrer';
+        titleLink.setAttribute('aria-label', `View ${repo.name} repository on GitHub`);
+        titleLink.textContent = repo.name;
+        title.appendChild(titleLink);
+
+        const meta = this.createProjectMeta(repo);
 
         const description = document.createElement('p');
-        description.textContent = repo.description || 'No description available';
+        description.textContent = repo.description || 'No description provided.';
+
+        const topics = this.createTopics(repo);
 
         const links = document.createElement('div');
         links.className = 'project-links';
 
         const repositoryLink = document.createElement('a');
-        repositoryLink.href = repo.html_url;
+        repositoryLink.href = repo.url;
         repositoryLink.target = '_blank';
         repositoryLink.rel = 'noopener noreferrer';
         repositoryLink.setAttribute('aria-label', `View ${repo.name} repository on GitHub`);
@@ -697,7 +849,11 @@ class GitHubProjectsManager {
             links.appendChild(homepageLink);
         }
 
-        card.append(title, description, links);
+        card.append(title, meta, description);
+        if (topics) {
+            card.appendChild(topics);
+        }
+        card.appendChild(links);
         return card;
     }
 

--- a/js/github-projects-manager.js
+++ b/js/github-projects-manager.js
@@ -3,6 +3,7 @@ export class GitHubProjectsManager {
     constructor() {
         this.projectsContainer = null;
         this.requestTimeoutMs = 5000;
+        this.defaultMaxRepos = 6;
     }
 
     async fetchJson(url) {
@@ -30,10 +31,86 @@ export class GitHubProjectsManager {
         this.projectsContainer.replaceChildren(messageElement);
     }
 
-    // Fetch GitHub projects with "featured" topic using Search API
+    getSettings(config) {
+        const settings = config.github_projects || {};
+        const username = config.github_username;
+        const excludedRepos = new Set([
+            username,
+            ...(settings.excluded_repos || [])
+        ].filter(Boolean));
+
+        return {
+            sourceUrl: settings.source_url,
+            maxRepos: Number.isInteger(settings.max_repos) ? settings.max_repos : this.defaultMaxRepos,
+            excludedRepos
+        };
+    }
+
+    normalizeRepo(repo) {
+        return {
+            name: repo.name,
+            description: repo.description || '',
+            url: repo.html_url || repo.url,
+            homepage: repo.homepage || '',
+            language: repo.language || '',
+            stars: repo.stars ?? repo.stargazers_count ?? 0,
+            forks: repo.forks ?? repo.forks_count ?? 0,
+            topics: repo.topics || [],
+            updatedAt: repo.updatedAt || repo.updated_at || '',
+            pushedAt: repo.pushedAt || repo.pushed_at || ''
+        };
+    }
+
+    getDisplayRepos(repos, settings) {
+        return repos
+            .map(repo => this.normalizeRepo(repo))
+            .filter(repo => repo.name && repo.url)
+            .filter(repo => !settings.excludedRepos.has(repo.name))
+            .sort((a, b) => {
+                if (b.stars !== a.stars) {
+                    return b.stars - a.stars;
+                }
+
+                const bDate = Date.parse(b.pushedAt || b.updatedAt) || 0;
+                const aDate = Date.parse(a.pushedAt || a.updatedAt) || 0;
+                return bDate - aDate;
+            })
+            .slice(0, settings.maxRepos);
+    }
+
+    async fetchFromProfileFeed(settings) {
+        if (!settings.sourceUrl) {
+            return [];
+        }
+
+        const repos = await this.fetchJson(settings.sourceUrl);
+        if (!Array.isArray(repos)) {
+            throw new Error('Top repositories feed must return an array');
+        }
+
+        return this.getDisplayRepos(repos, settings);
+    }
+
+    async fetchFromGitHubSearch(username, settings) {
+        const query = encodeURIComponent(`user:${username} fork:false archived:false`);
+        const perPage = Math.min(100, settings.maxRepos + settings.excludedRepos.size + 5);
+        const data = await this.fetchJson(`https://api.github.com/search/repositories?q=${query}&sort=stars&order=desc&per_page=${perPage}`);
+
+        return this.getDisplayRepos(data.items || [], settings);
+    }
+
+    async fetchFromGitHubRepos(username, settings) {
+        const repos = await this.fetchJson(`https://api.github.com/users/${username}/repos?type=owner&sort=updated&per_page=100`);
+        const publicRepos = repos.filter(repo => !repo.fork && !repo.archived);
+
+        return this.getDisplayRepos(publicRepos, settings);
+    }
+
+    // Fetch most-starred GitHub projects from the profile feed, then fall back to GitHub APIs.
     async fetchGitHubProjects(config) {
         this.projectsContainer = document.getElementById('projects');
         const username = config.github_username;
+        const settings = this.getSettings(config);
 
         if (!this.projectsContainer) {
             console.warn('Projects container not found, skipping GitHub projects');
@@ -46,41 +123,106 @@ export class GitHubProjectsManager {
         }
         
         try {
-            // Clear loading message
             this.projectsContainer.innerHTML = '';
-            
-            // Use GitHub Search API to find repositories with the "featured" topic
-            // This is more efficient than fetching all repos and filtering in the browser
-            const query = encodeURIComponent(`user:${username} topic:featured`);
-            const data = await this.fetchJson(`https://api.github.com/search/repositories?q=${query}&sort=updated&order=desc`);
-            const featuredRepos = data.items || [];
-            
-            if (featuredRepos.length > 0) {
-                this.renderProjects(featuredRepos, username);
-            } else {
-                this.setMessage('No featured repositories found.');
+
+            const topRepos = await this.fetchFromProfileFeed(settings);
+
+            if (topRepos.length > 0) {
+                this.renderProjects(topRepos, username);
+                return;
             }
+
+            throw new Error('Top repositories feed did not return any projects');
         } catch (error) {
-            console.warn('GitHub Search API failed, falling back to all repos fetch', error);
-            return this.fetchGitHubProjectsFallback(username);
+            console.warn('Top repositories feed failed, falling back to GitHub Search API', error);
+            return this.fetchGitHubProjectsFallback(username, settings);
         }
     }
 
-    // Fallback method to fetch all repos if Search API is unavailable
-    async fetchGitHubProjectsFallback(username) {
+    // Fallback method to fetch most-starred repos if the profile feed is unavailable
+    async fetchGitHubProjectsFallback(username, settings) {
         try {
-            const repos = await this.fetchJson(`https://api.github.com/users/${username}/repos?sort=updated&per_page=100`);
-            const featuredRepos = repos.filter(repo => repo.topics && repo.topics.includes('featured'));
-            
-            if (featuredRepos.length > 0) {
-                this.renderProjects(featuredRepos, username);
+            const topRepos = await this.fetchFromGitHubSearch(username, settings);
+
+            if (topRepos.length > 0) {
+                this.renderProjects(topRepos, username);
+                return;
+            }
+
+            throw new Error('GitHub Search API did not return any projects');
+        } catch (error) {
+            console.warn('GitHub Search API failed, falling back to user repositories', error);
+            return this.fetchGitHubProjectsReposFallback(username, settings);
+        }
+    }
+
+    async fetchGitHubProjectsReposFallback(username, settings) {
+        try {
+            const topRepos = await this.fetchFromGitHubRepos(username, settings);
+
+            if (topRepos.length > 0) {
+                this.renderProjects(topRepos, username);
             } else {
-                this.setMessage('No featured repositories found.');
+                this.setMessage('No public repositories found.');
             }
         } catch (error) {
             this.setMessage('GitHub projects are temporarily unavailable.');
             console.error('Error loading GitHub projects:', error);
         }
+    }
+
+    formatNumber(value) {
+        return new Intl.NumberFormat('en-US').format(value || 0);
+    }
+
+    createProjectMeta(repo) {
+        const meta = document.createElement('div');
+        meta.className = 'project-meta';
+
+        const stats = [
+            { icon: 'star', label: `${this.formatNumber(repo.stars)} stars` },
+            { icon: 'call_split', label: `${this.formatNumber(repo.forks)} forks` }
+        ];
+
+        if (repo.language) {
+            stats.push({ icon: 'code', label: repo.language });
+        }
+
+        stats.forEach(stat => {
+            const item = document.createElement('span');
+            item.className = 'project-stat';
+
+            const icon = document.createElement('span');
+            icon.className = 'material-symbols-outlined';
+            icon.setAttribute('aria-hidden', 'true');
+            icon.textContent = stat.icon;
+
+            const label = document.createElement('span');
+            label.textContent = stat.label;
+
+            item.append(icon, label);
+            meta.appendChild(item);
+        });
+
+        return meta;
+    }
+
+    createTopics(repo) {
+        const topics = repo.topics.slice(0, 3);
+        if (topics.length === 0) {
+            return null;
+        }
+
+        const topicList = document.createElement('div');
+        topicList.className = 'project-topics';
+
+        topics.forEach(topic => {
+            const item = document.createElement('span');
+            item.textContent = topic;
+            topicList.appendChild(item);
+        });
+
+        return topicList;
     }
 
     // Render GitHub projects
@@ -103,16 +245,26 @@ export class GitHubProjectsManager {
         card.style.animationDelay = `${index * 0.1}s`;
 
         const title = document.createElement('h3');
-        title.textContent = repo.name;
+        const titleLink = document.createElement('a');
+        titleLink.href = repo.url;
+        titleLink.target = '_blank';
+        titleLink.rel = 'noopener noreferrer';
+        titleLink.setAttribute('aria-label', `View ${repo.name} repository on GitHub`);
+        titleLink.textContent = repo.name;
+        title.appendChild(titleLink);
+
+        const meta = this.createProjectMeta(repo);
 
         const description = document.createElement('p');
-        description.textContent = repo.description || 'No description available';
+        description.textContent = repo.description || 'No description provided.';
+
+        const topics = this.createTopics(repo);
 
         const links = document.createElement('div');
         links.className = 'project-links';
 
         const repositoryLink = document.createElement('a');
-        repositoryLink.href = repo.html_url;
+        repositoryLink.href = repo.url;
         repositoryLink.target = '_blank';
         repositoryLink.rel = 'noopener noreferrer';
         repositoryLink.setAttribute('aria-label', `View ${repo.name} repository on GitHub`);
@@ -129,7 +281,11 @@ export class GitHubProjectsManager {
             links.appendChild(homepageLink);
         }
 
-        card.append(title, description, links);
+        card.append(title, meta, description);
+        if (topics) {
+            card.appendChild(topics);
+        }
+        card.appendChild(links);
         return card;
     }
 


### PR DESCRIPTION
## Summary
- Switch the portfolio GitHub projects section to show most-starred repositories instead of topic-based featured projects.
- Point the section at the reusable profile repository feed from `yashrajnayak/yashrajnayak`.
- Add GitHub API fallbacks so the portfolio still renders most-starred repos before or during feed outages.
- Display stars, forks, language, and topics in the existing project-card style.

## Validation
- Ran `npm run build` to regenerate `css/bundle.css` and `js/bundle.js`.
- Ran `node --check js/github-projects-manager.js` and `node --check js/bundle.js`.
- Parsed `config.json` successfully.
- Verified fallback URL normalization keeps repository links on `github.com`, not API URLs.
- Checked the site with local static hosting and Chrome headless; the rendered DOM showed 6 cards under `Most Starred GitHub Projects`.
- Scanned for local machine paths before pushing.